### PR TITLE
TCP-1192 Scotland eligibility update

### DIFF
--- a/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
+++ b/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
@@ -23,7 +23,7 @@
     </p>
 
     <p class="govuk-body">
-        You can also find <a href="https://www.nhs.uk/every-mind-matters/coronavirus/" class="govuk-link" target="_blank" rel="noopener noreferrer">advice and support if you're worried about COVID-19 (opens in a new tab)</a>.
+        You can also find <a href="https://www.nhs.uk/every-mind-matters/coronavirus/" class="govuk-link" target="_blank" rel="noopener noreferrer">advice and support if you're worried about COVID-19 (opens in new tab)</a>.
     </p>
 
     <h2 class="govuk-heading-m">

--- a/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
+++ b/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
@@ -19,7 +19,7 @@
     </p>
 
     <p class="govuk-body">
-        <a href="https://www.mygov.scot/self-isolation-grant" class="govuk-link" target="_blank" rel="noopener noreferrer">Find out what to do if you think you have COVID-19 (opens in new tab)</a>. If you're worried, or your symptoms get worse, contact 111 or speak to your GP. In an emergency dial 999.
+        <a href="https://www.nhsinform.scot/illnesses-and-conditions/infections-and-poisoning/coronavirus-covid-19/coronavirus-covid-19/" class="govuk-link" target="_blank" rel="noopener noreferrer">Find out what to do if you think you have COVID-19 (opens in new tab)</a>. If you're worried, or your symptoms get worse, contact 111 or speak to your GP. In an emergency dial 999.
     </p>
 
     <p class="govuk-body">

--- a/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
+++ b/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
@@ -8,34 +8,22 @@
         {{ pageTitle }}
     </h1>
 
-    <p class="govuk-body">In Scotland, you can only get free rapid lateral flow tests if you're: </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-        <li>
-            eligible for <a href="https://www.nhsinform.scot/covid19treatments" class="govuk-link" target="_blank" rel="noopener noreferrer">COVID-19 treatments</a>
-        </li>
-        <li>
-            visiting a care home or hospital 
-        </li>
-        <li>
-            an <a href="https://www.nhsinform.scot/illnesses-and-conditions/infections-and-poisoning/coronavirus-covid-19/coronavirus-covid-19/" class="govuk-link" target="_blank" rel="noopener noreferrer">unpaid carer</a>
-        </li>
-    </ul>
+    <p class="govuk-body">In Scotland, you can only get free rapid lateral flow tests if you're eligible for <a href="https://www.nhsinform.scot/covid19treatments" class="govuk-link" target="_blank" rel="noopener noreferrer">COVID-19 treatments (opens in a new tab)</a></p>
 
     <h2 class="govuk-heading-m">
-        If you are not eligible for tests 
+        If you are not eligible for rapid lateral flow tests
     </h2>
 
     <p class="govuk-body">
-        If you or someone you care for is eligible for the Self Isolation Support Grant, you should <a href="https://www.nhsinform.scot/illnesses-and-conditions/infections-and-poisoning/coronavirus-covid-19/coronavirus-covid-19/" class="govuk-link">book a PCR test online</a>  or call 119. <a href="https://www.mygov.scot/self-isolation-grant" class="govuk-link">Check if you are eligible</a>. 
+        <a href="https://www.mygov.scot/self-isolation-grant" class="govuk-link" target="_blank" rel="noopener noreferrer">Check if you or someone you care for is eligible for a Self Isolation Support Grant (opens in new tab)</a>, as you may be eligible for a PCR test.
     </p>
 
     <p class="govuk-body">
-       <a href="https://www.nhsinform.scot/illnesses-and-conditions/infections-and-poisoning/coronavirus-covid-19/coronavirus-covid-19/" class="govuk-link">Find out what to do if you think you have COVID-19</a>. If you're worried, or your symptoms get worse, speak to your GP or contact 111. In an emergency dial 999. 
+        <a href="https://www.mygov.scot/self-isolation-grant" class="govuk-link" target="_blank" rel="noopener noreferrer">Find out what to do if you think you have COVID-19 (opens in new tab)</a>. If you're worried, or your symptoms get worse, contact 111 or speak to your GP. In an emergency dial 999.
     </p>
 
     <p class="govuk-body">
-        You can also find <a href="https://www.nhs.uk/every-mind-matters/coronavirus/" class="govuk-link">advice and support if you're worried about COVID-19. </a>
+        You can also find <a href="https://www.nhs.uk/every-mind-matters/coronavirus/" class="govuk-link" target="_blank" rel="noopener noreferrer">advice and support if you're worried about COVID-19 (opens in a new tab)</a>.
     </p>
 
     <h2 class="govuk-heading-m">

--- a/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
+++ b/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
@@ -8,7 +8,7 @@
         {{ pageTitle }}
     </h1>
 
-    <p class="govuk-body">In Scotland, you can only get free rapid lateral flow tests if you're eligible for <a href="https://www.nhsinform.scot/covid19treatments" class="govuk-link" target="_blank" rel="noopener noreferrer">COVID-19 treatments (opens in a new tab)</a></p>
+    <p class="govuk-body">In Scotland, you can only get free rapid lateral flow tests if you're eligible for <a href="https://www.nhsinform.scot/covid19treatments" class="govuk-link" target="_blank" rel="noopener noreferrer">COVID-19 treatments (opens in new tab)</a></p>
 
     <h2 class="govuk-heading-m">
         If you are not eligible for rapid lateral flow tests

--- a/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
+++ b/app/views/order-lateral-flow-kits/scotland/eligibility-scotland.html
@@ -8,7 +8,7 @@
         {{ pageTitle }}
     </h1>
 
-    <p class="govuk-body">In Scotland, you can only get free rapid lateral flow tests if you're eligible for <a href="https://www.nhsinform.scot/covid19treatments" class="govuk-link" target="_blank" rel="noopener noreferrer">COVID-19 treatments (opens in new tab)</a></p>
+    <p class="govuk-body">In Scotland, you can only get free rapid lateral flow tests if you're eligible for <a href="https://www.nhsinform.scot/covid19treatments" class="govuk-link" target="_blank" rel="noopener noreferrer">COVID-19 treatments (opens in new tab)</a>.</p>
 
     <h2 class="govuk-heading-m">
         If you are not eligible for rapid lateral flow tests


### PR DESCRIPTION
Eligibility for lateral flow tests in Scotland is changing. The guidance for individuals visiting care homes or hospitals and unpaid carers to use lateral flow tests is being paused. We therefore need to remove the eligibility criteria for those two cohorts from the LFD ordering page for Scotland. 